### PR TITLE
Generate a package using Rollup

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,3 +19,5 @@ jobs:
       run: yarn build
     - name: Test
       run: yarn test
+    - name: Build package
+      run: yarn package

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
+dist/
 node_modules/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ureact",
   "version": "0.1.0",
   "description": "Small React-like UI library",
-  "main": "build/index.js",
+  "main": "dist/index.js",
   "repository": "https://github.com/robertknight/ureact",
   "author": "Robert Knight <robertknight@gmail.com>",
   "license": "MIT",
@@ -11,13 +11,18 @@
     "jsdom": "^16.4.0",
     "mocha": "^8.2.1",
     "prettier": "^2.2.1",
+    "rollup": "^2.35.1",
     "sinon": "^9.2.2",
     "typescript": "^4.1.3"
   },
   "scripts": {
     "build": "tsc",
+    "package": "rollup -c",
     "checkformatting": "prettier --check **/*.{js,ts}",
     "format": "prettier --list-different --write **/*.{js,ts}",
     "test": "mocha"
-  }
+  },
+  "files": [
+    "dist/**"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
   },
   "files": [
     "dist/**"
-  ]
+  ],
+  "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ureact",
   "version": "0.1.0",
   "description": "Small React-like UI library",
-  "main": "dist/index.js",
+  "main": "dist/ureact.js",
   "repository": "https://github.com/robertknight/ureact",
   "author": "Robert Knight <robertknight@gmail.com>",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,7 @@
+export default {
+  input: "build/index.js",
+  output: {
+    dir: "dist",
+    format: "cjs",
+  },
+};

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,6 @@
 export default {
   input: "build/index.js",
   output: {
-    dir: "dist",
-    format: "cjs",
+    file: "dist/ureact.js",
   },
 };

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import { registerContext, useRef } from "./hooks";
+import { registerContext, useRef } from "./hooks.js";
 
 export class ContextProvider<T> {
   private _listeners: Array<() => void>;

--- a/src/dom-props.ts
+++ b/src/dom-props.ts
@@ -1,4 +1,4 @@
-import { Props } from "./jsx";
+import { Props } from "./jsx.js";
 
 // Properties added to DOM elements rendered by UReact.
 interface UReactElement extends Element {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,4 +1,4 @@
-import { ContextProvider } from "./context";
+import { ContextProvider } from "./context.js";
 
 interface StateHook<S> {
   type: "state";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-export { createElement, isValidElement, jsx } from "./jsx";
-export { render, unmountComponentAtNode } from "./render";
-export { createContext } from "./context";
+export { createElement, isValidElement, jsx } from "./jsx.js";
+export { render, unmountComponentAtNode } from "./render.js";
+export { createContext } from "./context.js";
 export {
   useCallback,
   useContext,
@@ -10,5 +10,5 @@ export {
   useReducer,
   useRef,
   useState,
-} from "./hooks";
-export { Fragment, createRef, memo } from "./utils";
+} from "./hooks.js";
+export { Fragment, createRef, memo } from "./utils.js";

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,7 +1,7 @@
-import { Props, VNode, VNodeChildren, isValidElement } from "./jsx";
-import { ContextProvider } from "./context";
-import { EffectTiming, HookState, setHookState } from "./hooks";
-import { diffElementProps } from "./dom-props";
+import { Props, VNode, VNodeChildren, isValidElement } from "./jsx.js";
+import { ContextProvider } from "./context.js";
+import { EffectTiming, HookState, setHookState } from "./hooks.js";
+import { diffElementProps } from "./dom-props.js";
 
 /**
  * Backing tree for a rendered vnode.

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,4 +1,4 @@
-import { getRoots } from "./render";
+import { getRoots } from "./render.js";
 
 let actDepth = 0;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
-import { Props, Ref, VNodeChildren } from "./jsx";
+import { Props, Ref, VNodeChildren } from "./jsx.js";
 
-import { useMemo, useRef } from "./hooks";
+import { useMemo, useRef } from "./hooks.js";
 
 export function Fragment(props: Props) {
   return props.children;

--- a/test/context.js
+++ b/test/context.js
@@ -1,16 +1,17 @@
-const { assert } = require("chai");
-const sinon = require("sinon");
-const { JSDOM } = require("jsdom");
+import chai from "chai";
+import sinon from "sinon";
+import { JSDOM } from "jsdom";
+const { assert } = chai;
 
-const {
-  createElement: h,
+import {
+  createElement as h,
   render,
   createContext,
   useContext,
   useMemo,
-} = require("../build/index");
+} from "../build/index.js";
 
-const { delay } = require("./utils/delay");
+import { delay } from "./utils/delay.js";
 
 describe("context", () => {
   let jsdom;

--- a/test/hooks.js
+++ b/test/hooks.js
@@ -1,11 +1,11 @@
-const { assert } = require("chai");
-const sinon = require("sinon");
-const { JSDOM } = require("jsdom");
+import chai from "chai";
+import * as sinon from "sinon";
+import { JSDOM } from "jsdom";
+const { assert } = chai;
 
-const {
-  createElement: h,
+import {
+  createElement as h,
   render,
-
   useCallback,
   // `useContext` is not here because it is tested separately.
   useEffect,
@@ -14,7 +14,7 @@ const {
   useReducer,
   useRef,
   useState,
-} = require("../build/index");
+} from "../build/index.js";
 
 describe("hooks", () => {
   let jsdom;

--- a/test/jsx.js
+++ b/test/jsx.js
@@ -1,7 +1,8 @@
-const { assert } = require("chai");
+import chai from "chai";
+const { assert } = chai;
 
-const { elementSymbol } = require("../build/jsx");
-const { createElement, isValidElement } = require("../build");
+import { elementSymbol } from "../build/jsx.js";
+import { createElement, isValidElement } from "../build/index.js";
 
 describe("JSX", () => {
   describe("createElement", () => {

--- a/test/render.js
+++ b/test/render.js
@@ -1,12 +1,13 @@
-const { assert } = require("chai");
-const sinon = require("sinon");
-const { JSDOM } = require("jsdom");
+import chai from "chai";
+import sinon from "sinon";
+import { JSDOM } from "jsdom";
+const { assert } = chai;
 
-const {
-  createElement: h,
+import {
+  createElement as h,
   render,
   unmountComponentAtNode,
-} = require("../build/index");
+} from "../build/index.js";
 
 /**
  * Attach a numeric tag, starting at 1, to each node in a sequence.

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,16 +1,17 @@
-const { assert } = require("chai");
-const sinon = require("sinon");
-const { JSDOM } = require("jsdom");
+import chai from "chai";
+import * as sinon from "sinon";
+import { JSDOM } from "jsdom";
+const { assert } = chai;
 
-const {
-  createElement: h,
+import {
+  createElement as h,
   render,
   useEffect,
   useLayoutEffect,
   useState,
-} = require("../build/index");
+} from "../build/index.js";
 
-const { act } = require("../build/test-utils");
+import { act } from "../build/test-utils.js";
 
 describe("test-utils", () => {
   let jsdom;

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,15 +1,15 @@
-const { assert } = require("chai");
-const sinon = require("sinon");
-const { JSDOM } = require("jsdom");
+import chai from "chai";
+import * as sinon from "sinon";
+import { JSDOM } from "jsdom";
+const { assert } = chai;
 
-const {
-  createElement: h,
+import {
+  createElement as h,
   render,
-
   Fragment,
   createRef,
   memo,
-} = require("../build/index");
+} from "../build/index.js";
 
 describe("utilities", () => {
   let jsdom;

--- a/test/utils/delay.js
+++ b/test/utils/delay.js
@@ -1,5 +1,3 @@
-function delay(ms) {
+export function delay(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
-
-module.exports = { delay };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   /* Visit https://aka.ms/tsconfig.json to read more about this file */
   "compilerOptions": {
     "target": "es2017",
-    "module": "commonjs",
+    "module": "es2020",
     "lib": ["es2020", "dom"],
     "outDir": "./build",
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,6 +1064,13 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+rollup@^2.35.1:
+  version "2.35.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.35.1.tgz#e6bc8d10893556a638066f89e8c97f422d03968c"
+  integrity sha512-q5KxEyWpprAIcainhVy6HfRttD9kutQpHbeqDTWnqAFNJotiojetK6uqmcydNMymBEtC4I8bCYR+J3mTMqeaUA==
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"


### PR DESCRIPTION
Compile all the modules into a single package in the `dist/` directory using Rollup.

To do this with minimal adding tooling required changing TypeScript compilation to output native ES modules into the `build/` directory. This in turn required changing the whole package to a native ES module package by editing the `type` field in `package.json` and rewriting import specifiers to include a file extension.

Somewhat confusingly, the extension in the .ts source files needs to end in .js. See https://github.com/microsoft/TypeScript/issues/42151#issuecomment-753506506.